### PR TITLE
Fix build errors caused by rendering issues.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,9 @@ export default function RootLayout({
             ) : (
             <main>{children}</main>
             )
-        ) : null}
+        ) : (
+          <main>{children}</main>
+        )}
         {isClient && <Toaster />}
       </body>
     </html>

--- a/src/app/learn/page.tsx
+++ b/src/app/learn/page.tsx
@@ -26,9 +26,7 @@ import './learn.css';
 export default function LearnPage() {
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState(1);
-  const [selectedOption, setSelectedOption] = useState<HTMLElement | null>(
-    null
-  );
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
   const [showFeedback, setShowFeedback] = useState(false);
   const [showNextButton, setShowNextButton] = useState(false);
@@ -80,14 +78,10 @@ export default function LearnPage() {
     }
   };
 
-  const handleSelectOption = (
-    e: React.MouseEvent<HTMLButtonElement>,
-    option: string
-  ) => {
-    const target = e.currentTarget;
+  const handleSelectOption = (option: string) => {
     if (selectedOption !== null) return;
 
-    setSelectedOption(target);
+    setSelectedOption(option);
     const correct = option === questions[currentStep - 1].answer;
     setIsCorrect(correct);
     setShowFeedback(true);
@@ -248,11 +242,11 @@ export default function LearnPage() {
                 <button
                   key={index}
                   className={`option ${
-                    selectedOption === event?.target && isCorrect === true
+                    selectedOption === option && isCorrect === true
                       ? 'correct'
                       : ''
                   } ${
-                    selectedOption === event?.target && isCorrect === false
+                    selectedOption === option && isCorrect === false
                       ? 'incorrect'
                       : ''
                   } ${
@@ -262,7 +256,7 @@ export default function LearnPage() {
                       ? 'correct'
                       : ''
                   }`}
-                  onClick={(e) => handleSelectOption(e, option)}
+                  onClick={() => handleSelectOption(option)}
                   disabled={showFeedback}
                 >
                   {option}


### PR DESCRIPTION
This commit addresses two separate issues that were causing the `next build` command to fail.

1.  In `src/app/layout.tsx`, the root layout was wrapped in `'use client'` and conditionally rendered its children based on a `isClient` state. This prevented the content from being rendered on the server during prerendering, causing a build failure on the root page. The fix ensures that children are always rendered on the server.

2.  In `src/app/learn/page.tsx`, a `ReferenceError: event is not defined` occurred during prerendering. This was caused by using an `event` variable inside a `.map()` function's `className` property, where it was not defined. The code was refactored to store the selected option's string value in state instead of its DOM element, which is a more robust approach and fixes the reference error.