### PR TITLE
Fix build issues with blendshape scoring and font fetching

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,6 @@
 import './globals.css';
 import { cn } from '@/lib/utils';
 import ClientShell from '@/components/ClientShell';
-import { Inter, Space_Grotesk } from 'next/font/google';
-
-const inter = Inter({ subsets: ['latin'], display: 'swap' });
-const spaceGrotesk = Space_Grotesk({ subsets: ['latin'], display: 'swap', weight: ['500','700'] });
 
 export default function RootLayout({
   children,
@@ -17,8 +13,14 @@ export default function RootLayout({
       <head>
         <title>PulseStudy - 学びの、その先へ</title>
         <meta name="description" content="スナック学習とAIコーチで、『続かない』を『楽しい』に変えよう" />
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Inter&family=Space+Grotesk:wght@500;700&display=swap"
+          rel="stylesheet"
+        />
       </head>
-      <body className={cn('antialiased', inter.className, spaceGrotesk.className)}>
+      <body className={cn('antialiased')}>
         <ClientShell>{children}</ClientShell>
       </body>
     </html>

--- a/src/types/mediapipe.d.ts
+++ b/src/types/mediapipe.d.ts
@@ -1,0 +1,8 @@
+declare module '@mediapipe/tasks-vision' {
+  export type FaceLandmarker = any;
+  export const FaceLandmarker: any;
+  export type FilesetResolver = any;
+  export const FilesetResolver: any;
+  export type DrawingUtils = any;
+  export const DrawingUtils: any;
+}

--- a/src/workers/pulse.worker.ts
+++ b/src/workers/pulse.worker.ts
@@ -77,9 +77,13 @@ onmessage = async (ev: MessageEvent<MsgIn>) => {
     const poseScore = 1 - posePenalty
 
     // 3. Expression Score from Blendshapes
-    const blendshapes = faceBlendshapes![0].categories
-    const browDown = (blendshapes.find(c => c.categoryName === 'browDownLeft')?.score ?? 0 + blendshapes.find(c => c.categoryName === 'browDownRight')?.score ?? 0) / 2
-    const mouthPress = blendshapes.find(c => c.categoryName === 'mouthPressLeft')?.score ?? 0 + blendshapes.find(c => c.categoryName === 'mouthPressRight')?.score ?? 0
+    const blendshapes = faceBlendshapes![0].categories as Array<{ categoryName: string; score: number }>
+    const browDownLeft = blendshapes.find(c => c.categoryName === 'browDownLeft')?.score ?? 0
+    const browDownRight = blendshapes.find(c => c.categoryName === 'browDownRight')?.score ?? 0
+    const browDown = (browDownLeft + browDownRight) / 2
+    const mouthPressLeft = blendshapes.find(c => c.categoryName === 'mouthPressLeft')?.score ?? 0
+    const mouthPressRight = blendshapes.find(c => c.categoryName === 'mouthPressRight')?.score ?? 0
+    const mouthPress = mouthPressLeft + mouthPressRight
 
     // Confusion/Concentration is often tied to browDown.
     // We'll treat it as a positive indicator for focus, up to a point.


### PR DESCRIPTION
## Summary
- resolve undefined blendshape access in pulse worker and add mediapipe types
- avoid build-time Google font downloads by linking fonts in layout

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec0ee70748327b7be7ffd90ca844c