### PR TITLE
feat: allow external video element and improve focus feedback

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,6 +1,6 @@
 ﻿"use client"
 
-import { useEffect, useMemo, useState, useCallback } from 'react'
+import { useEffect, useMemo, useState, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Avatar, AvatarFallback } from '@/components/ui/avatar'
@@ -42,10 +42,13 @@ function PulseController() {
     setCameraPermission(status)
   }, [setCameraPermission])
 
+  const videoRef = useRef<HTMLVideoElement | null>(null)
+
   usePulseEngine({
     enabled: isPulseEngineEnabled,
     onUpdate: handleUpdate,
     onPermissionChange: handlePermissionChange,
+    videoEl: videoRef.current,
   })
 
   const handleToggle = () => {
@@ -65,20 +68,23 @@ function PulseController() {
     denied: 'カメラがブロックされています',
   }[cameraPermission]
 
-  if (cameraPermission === 'granted' && isPulseEngineEnabled) {
-    return (
-         <Button onClick={handleToggle} variant="secondary" className="w-full mt-2">
+  const button = (cameraPermission === 'granted' && isPulseEngineEnabled) ? (
+        <Button onClick={handleToggle} variant="secondary" className="w-full mt-2">
             <VideoOff className="mr-2 h-4 w-4" />
             計測を停止
         </Button>
-    )
-  }
+  ) : (
+        <Button onClick={handleToggle} disabled={cameraPermission === 'pending' || cameraPermission === 'denied'} className="w-full mt-2">
+            <Video className="mr-2 h-4 w-4" />
+            {buttonText}
+        </Button>
+  )
 
   return (
-    <Button onClick={handleToggle} disabled={cameraPermission === 'pending' || cameraPermission === 'denied'} className="w-full mt-2">
-        <Video className="mr-2 h-4 w-4" />
-        {buttonText}
-    </Button>
+    <>
+      <video ref={videoRef} muted playsInline autoPlay style={{ display: 'none' }} />
+      {button}
+    </>
   )
 }
 

--- a/src/components/profile/FocusMeterCard.tsx
+++ b/src/components/profile/FocusMeterCard.tsx
@@ -11,6 +11,13 @@ export function FocusMeterCard() {
 
   const isRunning = output.state !== 'paused';
 
+  const stateMessages: Record<string, string> = {
+    active: '計測中です',
+    paused: '別タブにいるため一時停止しています',
+    'no-signal': '顔が検出できません',
+    warming_up: '計測を準備しています…',
+  };
+
   const getStatusVariant = (state: string): VariantProps<typeof badgeVariants>['variant'] => {
     switch(state) {
       case 'active': return 'default';
@@ -40,10 +47,13 @@ export function FocusMeterCard() {
             <Button onClick={stop} disabled={!isRunning} variant="outline">停止</Button>
           </div>
         </div>
-        {isRunning && output.state !== 'warming_up' && (
-            <div className="mt-4">
-                <p className="text-sm text-muted-foreground">現在の集中度: {Math.round(output.value * 100)}%</p>
-            </div>
+        <div className="mt-2 text-sm text-muted-foreground" role="status">
+          {stateMessages[output.state] || ''}
+        </div>
+        {isRunning && output.state === 'active' && (
+          <div className="mt-4">
+            <p className="text-sm text-muted-foreground">現在の集中度: {Math.round(output.value * 100)}%</p>
+          </div>
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
- allow providing a DOM video element to `usePulseEngine` for Safari stability
- tighten dev-only MediaPipe log suppression using stack traces
- surface clearer focus status messages in `FocusMeterCard`
- hook up hidden video element in home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prompts for ESLint setup)
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68bff82c04d48327b227af410cf25a8a