### PR TITLE
feat: Add learning summary page

### DIFF
--- a/src/app/learn/[subjectId]/summary/page.tsx
+++ b/src/app/learn/[subjectId]/summary/page.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { notFound } from 'next/navigation';
+import { summaryData } from '@/lib/summary-data';
+import { Button } from '@/components/ui/button';
+import { HelpCircle, Mic, BookOpen, ChevronLeft } from 'lucide-react';
+
+export default function SummaryPage({ params }: { params: { subjectId: string } }) {
+  const data = summaryData[params.subjectId];
+
+  if (!data) {
+    notFound();
+  }
+
+  const { title, subject, progress, points, imageUrl, imageAlt } = data;
+  const progressPercentage = (parseInt(progress.split('/')[0]) / parseInt(progress.split('/')[1])) * 100;
+
+  return (
+    <div className="flex-1 p-8 bg-background text-foreground">
+      <header className="flex justify-between items-center mb-6">
+        <div>
+          <h2 className="text-2xl font-bold text-foreground">{title}</h2>
+          <div className="flex items-center gap-4 mt-2">
+            <span className="text-muted-foreground">{subject} {progress}</span>
+            <div className="w-64 h-2 rounded-full bg-secondary">
+              <div className="h-2 rounded-full bg-primary" style={{ width: `${progressPercentage}%` }}></div>
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="bg-muted p-2 rounded-lg cursor-pointer border">
+            <BookOpen className="text-yellow-400" />
+          </div>
+          <div className="bg-muted p-2 rounded-lg cursor-pointer border">
+            <Mic className="text-blue-400" />
+          </div>
+          <div className="bg-muted p-2 rounded-lg cursor-pointer border">
+            <HelpCircle className="text-red-400" />
+          </div>
+        </div>
+      </header>
+
+      <div className="bg-card p-8 rounded-xl border">
+        <h3 className="text-xl font-bold text-card-foreground mb-6">要点</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="space-y-4">
+            <ul className="space-y-3 text-muted-foreground list-disc list-inside">
+              {points.map((point, index) => (
+                <li key={index}>{point}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <Image
+              alt={imageAlt}
+              className="rounded-lg w-full h-auto"
+              src={imageUrl}
+              width={500}
+              height={300}
+              priority
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-between items-center">
+        <Link href="/learn-top" passHref>
+          <Button variant="ghost">
+            <ChevronLeft className="mr-2 h-4 w-4" />
+            学習選択へ
+          </Button>
+        </Link>
+        <Link href={`/learn?module=${params.subjectId}`} passHref>
+          <Button className="px-12 py-4 bg-orange-500 text-white font-bold rounded-lg hover:bg-orange-600 transition-colors text-lg">
+            問題へ
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/learn-top/AiRecommendationCard.tsx
+++ b/src/components/learn-top/AiRecommendationCard.tsx
@@ -32,7 +32,7 @@ export function AiRecommendationCard({ recommendation }: AiRecommendationCardPro
         <Clock className="h-4 w-4 mr-1" />
         <span>{durationMinutes}分</span>
       </div>
-      <Link href={`/learn?module=${moduleId}`} passHref>
+      <Link href={`/learn/${moduleId}/summary`} passHref>
         <button className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-lg mt-4">
           開始
         </button>

--- a/src/lib/summary-data.ts
+++ b/src/lib/summary-data.ts
@@ -1,0 +1,39 @@
+export interface SummaryData {
+  title: string;
+  subject: string;
+  progress: string;
+  points: string[];
+  imageUrl: string;
+  imageAlt: string;
+}
+
+export const summaryData: Record<string, SummaryData> = {
+  'math-quad-1': {
+    title: '二次関数のグラフ',
+    subject: '数学',
+    progress: '1/3',
+    points: [
+      '二次関数 y = ax^2 + bx + c のグラフは放物線になる。',
+      '係数 a はグラフの開き具合と向きを決める (a > 0 で下に凸, a < 0 で上に凸)。',
+      '頂点の座標は (-b/2a, - (b^2 - 4ac)/4a) で求められる。',
+      '軸の方程式は x = -b/2a である。',
+      'y切片は (0, c) となる。',
+    ],
+    imageUrl: 'https://lh3.googleusercontent.com/aida-public/AB6AXuAm7o5LykUIr0uHeY-VUg3cYt-DMmX_TvnfjQWkjZT3Bu-IQb6cX15O_FIB6OyiKl1JKKWg94q71M24WTR8Gx10UDt2P67kwfKqakQrMBlbmpC38vLJAmExCvZZbmgYGNPJFrAlMU3H1v1SuIzBJbV0AccGXHpbCz_0vRjvubVg51gH_Q49GX1O8Aptc5fJVGVnpPEcsPOyT47XsKICSjUwQdX4mmYH82qXzBT09pmZuFPp-0oikVQsZl7OW5_XaFQist7ma4QvhD4',
+    imageAlt: 'Graph of a quadratic function',
+  },
+  'eng-infinitive-1': {
+    title: '不定詞の基本',
+    subject: '英語',
+    progress: '1/4',
+    points: [
+      '不定詞は「to + 動詞の原形」の形をとる。',
+      '名詞的用法：「〜すること」と訳し、主語や目的語になる。',
+      '形容詞的用法：「〜するための」「〜すべき」と訳し、名詞を修飾する。',
+      '副詞的用法：「〜するために」「〜して」と訳し、動詞、形容詞、副詞を修飾する。',
+      'It is ... for A to do B の構文を覚えよう。',
+    ],
+    imageUrl: 'https://images.unsplash.com/photo-1516410529446-21e7e7811944?q=80&w=2070&auto=format&fit=crop',
+    imageAlt: 'A person writing English notes',
+  },
+};


### PR DESCRIPTION
Implements a new "key points" summary page that appears after a user selects a learning module and before the quiz begins.

This change introduces a new dynamic route at `/learn/[subjectId]/summary`. The page is a reusable component that displays topic-specific information (title, key points, image) while maintaining a consistent layout across all subjects.

- Creates the new summary page component at `src/app/learn/[subjectId]/summary/page.tsx`.
- Adds a data file `src/lib/summary-data.ts` to provide mock content for the summary pages.
- Updates the link in `AiRecommendationCard.tsx` to navigate to the new summary page instead of directly to the quiz.
- The new component's styling is aligned with the application's existing theme defined in `tailwind.config.ts` and `globals.css`.