### PR TITLE
fix: allow loading fonts from fonts.gstatic.com

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const securityHeaders = [
       "base-uri 'self'",
       "frame-ancestors 'self'",
       "img-src 'self' data: blob: https:",
-      "font-src 'self' data:",
+      "font-src 'self' data: https://fonts.gstatic.com",
       "connect-src 'self' data: blob: https: http: ws: wss: https://storage.googleapis.com",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net",
       "worker-src 'self' blob: https://cdn.jsdelivr.net",


### PR DESCRIPTION
## Summary
- allow fonts from fonts.gstatic.com in Content Security Policy to unblock Material Icons

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c16c9c443883278234c1d16c0624a6